### PR TITLE
Refatore dashboard em componentes reutilizáveis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,140 +1,41 @@
-import { useEffect } from 'react'
+import { useMemo } from 'react'
+import { Sidebar, Topbar, Hero, FinancialCards, CoursesList, InstructorsPanel, NoticesPanel } from './components/index.js'
 import { StudyProvider, useStudy } from './context/StudyContext.jsx'
 
-function Dashboard(){
-  const ctx = useStudy()
-  useEffect(()=>{
-    const formatDate = (d)=> d.toLocaleDateString('pt-BR',{year:'numeric',month:'long',day:'numeric'})
-    const el = document.getElementById('today')
-    if(el) el.textContent = formatDate(new Date())
-  },[])
+/**
+ * Container principal do dashboard, responsável por orquestrar os componentes de apresentação.
+ *
+ * @returns {import('react').JSX.Element} Estrutura do dashboard.
+ */
+function Dashboard () {
+  const study = useStudy()
 
-  const fmt = (v)=> v.toLocaleString('pt-BR',{style:'currency',currency:'BRL'})
+  const currentDate = useMemo(() => new Date(), [])
+
+  const financialCards = useMemo(() => ([
+    { icon: '💰', title: 'A contribuir', amount: study.financas.aContribuir },
+    { icon: '🧾', title: 'Contribuído no mês', amount: study.financas.contribuido, highlight: true },
+    { icon: '📈', title: 'Outros', amount: study.financas.outros }
+  ]), [
+    study.financas.aContribuir,
+    study.financas.contribuido,
+    study.financas.outros
+  ])
 
   return (
     <div className="app">
-      {/* Sidebar */}
-      <aside className="sidebar">
-        <div className="brand" aria-label="Logo">
-          <svg viewBox="0 0 24 24" role="img" aria-label="cap"><path d="M12 2 1 7l11 5 9-4.09V14h2V7L12 2zm-7 9.27V17c0 2.76 3.58 5 8 5s8-2.24 8-5v-2.73l-8 3.64-8-3.64z"/></svg>
-        </div>
-        <nav className="nav">
-          <a className="active" href="#"><span className="icon">🏠</span> Painel</a>
-          <a href="#"><span className="icon">💳</span> Contribuições</a>
-          <a href="#"><span className="icon">📝</span> Inscrição</a>
-          <a href="#"><span className="icon">📚</span> Planos de estudo</a>
-          <a href="#"><span className="icon">🗂️</span> Pausar módulo</a>
-          <a href="#"><span className="icon">🎯</span> Resultados</a>
-          <a href="#"><span className="icon">🔔</span> Avisos</a>
-          <a href="#"><span className="icon">📅</span> Agenda</a>
-        </nav>
-        <div className="spacer" />
-        <a className="nav logout" href="#"><span className="icon">🚪</span> Sair</a>
-      </aside>
-
-      {/* Main */}
+      <Sidebar />
       <main className="main">
-        <div className="topbar">
-          <div className="search" role="search">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M11 4a7 7 0 1 1 0 14 7 7 0 0 1 0-14Zm10 17-5.2-5.2" stroke="#999" strokeWidth="2" strokeLinecap="round"/></svg>
-            <input type="text" placeholder="Pesquisar" aria-label="search"
-              onFocus={(e)=>e.currentTarget.parentElement.style.boxShadow='0 12px 30px rgba(21,13,57,.12)'}
-              onBlur={(e)=>e.currentTarget.parentElement.style.boxShadow='var(--shadow)'} />
-          </div>
-          <div className="profile">
-            <div className="badge" title="alertas" />
-            <div className="avatar">BR</div>
-            <div>
-              <div style={{fontWeight:600,fontSize:13}}>{ctx.usuario.nome}</div>
-              <div style={{fontSize:11,color:'var(--muted)'}}>{ctx.usuario.periodo}</div>
-            </div>
-          </div>
-        </div>
-
-        <section className="hero">
-          <div>
-            <div className="date" id="today"></div>
-            <h2>Bem-vindo de volta, {ctx.usuario.nome}!</h2>
-            <p>Mantenha o estudo bíblico em dia no seu portal</p>
-          </div>
-          <div className="hero-illu" aria-hidden="true">
-            <div className="blob"></div>
-            <svg className="gradcap" width="120" height="120" viewBox="0 0 24 24" fill="#1f1646" opacity=".95"><path d="M12 3 1 8l11 5 11-5-11-5Zm-6 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3l-8 3.64L6 12Z"/></svg>
-          </div>
-        </section>
-
+        <Topbar usuario={study.usuario} />
+        <Hero username={study.usuario.nome} currentDate={currentDate} />
         <div className="grid">
-          <section>
-            <h3 className="section-title">Finanças</h3>
-            <div className="cards">
-              <div className="card">
-                <div className="kpi">
-                  <div className="kpi-icon">💰</div>
-                  <div>
-                    <div className="kpi-value">{fmt(ctx.financas.aContribuir)}</div>
-                    <div className="kpi-title">A contribuir</div>
-                  </div>
-                </div>
-              </div>
-              <div className="card" style={{outline:'3px solid var(--primary-200)'}}>
-                <div className="kpi">
-                  <div className="kpi-icon">🧾</div>
-                  <div>
-                    <div className="kpi-value">{fmt(ctx.financas.contribuido)}</div>
-                    <div className="kpi-title">Contribuído no mês</div>
-                  </div>
-                </div>
-              </div>
-              <div className="card">
-                <div className="kpi">
-                  <div className="kpi-icon">📈</div>
-                  <div>
-                    <div className="kpi-value">{fmt(ctx.financas.outros)}</div>
-                    <div className="kpi-title">Outros</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <h3 className="section-title" style={{marginTop:22}}>Planos em andamento</h3>
-            <div className="courses">
-              {ctx.cursos.map((c, i)=> (
-                <article key={i} className="course">
-                  <div className="thumb"></div>
-                  <div>
-                    <h4>{c.titulo}</h4>
-                    <p>{c.desc}</p>
-                  </div>
-                  <button className="btn">Ver</button>
-                </article>
-              ))}
-            </div>
-          </section>
-
+          <div>
+            <FinancialCards cards={financialCards} />
+            <CoursesList courses={study.cursos} />
+          </div>
           <aside>
-            <div className="panel">
-              <div style={{display:'flex',alignItems:'center',gap:8}}>
-                <h3 className="section-title" style={{margin:0}}>Instrutores</h3>
-              </div>
-              <div className="instructors">
-                {ctx.instrutores.map((i, idx)=> (<div key={idx} className="dot" title={i.nome}></div>))}
-              </div>
-            </div>
-
-            <div className="panel" style={{marginTop:18}}>
-              <div style={{display:'flex',alignItems:'center',gap:8,marginBottom:6}}>
-                <h3 className="section-title" style={{margin:0}}>Avisos do dia</h3>
-                <a className="seeall" href="#">Ver todos</a>
-              </div>
-              <div className="notice">
-                {ctx.avisos.map((n, idx)=> (
-                  <div key={idx} className="notice-item">
-                    <h4>{n.titulo}</h4>
-                    <p>{n.texto}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <InstructorsPanel instructors={study.instrutores} />
+            <NoticesPanel notices={study.avisos} />
           </aside>
         </div>
       </main>
@@ -142,7 +43,12 @@ function Dashboard(){
   )
 }
 
-export default function App(){
+/**
+ * Componente raiz do aplicativo, responsável por prover o contexto de estudos.
+ *
+ * @returns {import('react').JSX.Element} Aplicação com provedor de contexto.
+ */
+export default function App () {
   return (
     <StudyProvider>
       <Dashboard />

--- a/src/components/CoursesList.jsx
+++ b/src/components/CoursesList.jsx
@@ -1,0 +1,38 @@
+import { memo } from 'react'
+
+/**
+ * @typedef {Object} Course
+ * @property {string} titulo Título do curso.
+ * @property {string} desc Descrição resumida do curso.
+ */
+
+/**
+ * Lista de cursos em andamento para o usuário.
+ *
+ * @param {{ courses: Course[] }} props Propriedades com a lista de cursos.
+ * @returns {import('react').JSX.Element} Grade de cursos renderizada.
+ */
+function CoursesListComponent ({ courses }) {
+  return (
+    <section>
+      <h3 className="section-title" style={{ marginTop: 22 }}>Planos em andamento</h3>
+      <div className="courses">
+        {courses.map((course) => (
+          <article key={course.titulo} className="course">
+            <div className="thumb"></div>
+            <div>
+              <h4>{course.titulo}</h4>
+              <p>{course.desc}</p>
+            </div>
+            <button className="btn">Ver</button>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+const CoursesList = memo(CoursesListComponent)
+CoursesList.displayName = 'CoursesList'
+
+export default CoursesList

--- a/src/components/FinancialCards.jsx
+++ b/src/components/FinancialCards.jsx
@@ -1,0 +1,78 @@
+import { memo, useMemo } from 'react'
+
+/**
+ * @typedef {Object} FinancialCardDescriptor
+ * @property {string} icon Ícone exibido no cartão.
+ * @property {string} title Título do indicador.
+ * @property {number} amount Valor numérico a ser formatado como moeda.
+ * @property {boolean} [highlight] Indica se o cartão deve receber destaque visual.
+ */
+
+/**
+ * Cria um formatador de moeda memorizado para evitar alocações repetidas.
+ *
+ * @param {string} locale Locale utilizado para a formatação.
+ * @param {string} currency Código da moeda.
+ * @returns {(value: number) => string} Função que formata números para moeda.
+ */
+function useCurrencyFormatter (locale, currency) {
+  return useMemo(() => {
+    const formatter = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency
+    })
+    return (value) => formatter.format(value)
+  }, [locale, currency])
+}
+
+/**
+ * Cartão individual de informações financeiras.
+ *
+ * @param {FinancialCardDescriptor} props Propriedades do cartão.
+ * @returns {import('react').JSX.Element} Cartão renderizado.
+ */
+function FinancialCardComponent ({ icon, title, amount, highlight = false }) {
+  const formatCurrency = useCurrencyFormatter('pt-BR', 'BRL')
+
+  return (
+    <div className="card" style={highlight ? { outline: '3px solid var(--primary-200)' } : undefined}>
+      <div className="kpi">
+        <div className="kpi-icon">{icon}</div>
+        <div>
+          <div className="kpi-value">{formatCurrency(amount)}</div>
+          <div className="kpi-title">{title}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const FinancialCard = memo(FinancialCardComponent)
+FinancialCard.displayName = 'FinancialCards.Card'
+
+/**
+ * Lista de cartões financeiros, implementada com o padrão de componentes compostos
+ * para permitir variações futuras sem alterar o container.
+ *
+ * @param {{ cards: FinancialCardDescriptor[], children?: import('react').ReactNode }} props Propriedades do container.
+ * @returns {import('react').JSX.Element} Container renderizado dos cartões financeiros.
+ */
+function FinancialCardsComponent ({ cards, children }) {
+  return (
+    <section>
+      <h3 className="section-title">Finanças</h3>
+      <div className="cards">
+        {cards.map((card) => (
+          <FinancialCard key={card.title} {...card} />
+        ))}
+        {children}
+      </div>
+    </section>
+  )
+}
+
+const FinancialCards = memo(FinancialCardsComponent)
+FinancialCards.displayName = 'FinancialCards'
+FinancialCards.Card = FinancialCard
+
+export default FinancialCards

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,44 @@
+import { memo, useMemo } from 'react'
+
+/**
+ * @typedef {Object} HeroProps
+ * @property {string} username Nome do usuário exibido na saudação.
+ * @property {Date} currentDate Data atual exibida na interface.
+ */
+
+/**
+ * Seção hero com saudação personalizada e data atual.
+ *
+ * @param {HeroProps} props Propriedades do componente.
+ * @returns {import('react').JSX.Element} Estrutura visual da seção hero.
+ */
+function HeroComponent ({ username, currentDate }) {
+  const formattedDate = useMemo(() => (
+    new Intl.DateTimeFormat('pt-BR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(currentDate)
+  ), [currentDate])
+
+  return (
+    <section className="hero">
+      <div>
+        <div className="date">{formattedDate}</div>
+        <h2>Bem-vindo de volta, {username}!</h2>
+        <p>Mantenha o estudo bíblico em dia no seu portal</p>
+      </div>
+      <div className="hero-illu" aria-hidden="true">
+        <div className="blob"></div>
+        <svg className="gradcap" width="120" height="120" viewBox="0 0 24 24" fill="#1f1646" opacity=".95">
+          <path d="M12 3 1 8l11 5 11-5-11-5Zm-6 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3l-8 3.64L6 12Z" />
+        </svg>
+      </div>
+    </section>
+  )
+}
+
+const Hero = memo(HeroComponent)
+Hero.displayName = 'Hero'
+
+export default Hero

--- a/src/components/InstructorsPanel.jsx
+++ b/src/components/InstructorsPanel.jsx
@@ -1,0 +1,32 @@
+import { memo } from 'react'
+
+/**
+ * @typedef {Object} Instructor
+ * @property {string} nome Nome do instrutor.
+ */
+
+/**
+ * Painel lateral com os instrutores disponíveis.
+ *
+ * @param {{ instructors: Instructor[] }} props Propriedades contendo a lista de instrutores.
+ * @returns {import('react').JSX.Element} Painel de instrutores.
+ */
+function InstructorsPanelComponent ({ instructors }) {
+  return (
+    <div className="panel">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <h3 className="section-title" style={{ margin: 0 }}>Instrutores</h3>
+      </div>
+      <div className="instructors">
+        {instructors.map((instructor) => (
+          <div key={instructor.nome} className="dot" title={instructor.nome}></div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const InstructorsPanel = memo(InstructorsPanelComponent)
+InstructorsPanel.displayName = 'InstructorsPanel'
+
+export default InstructorsPanel

--- a/src/components/NoticesPanel.jsx
+++ b/src/components/NoticesPanel.jsx
@@ -1,0 +1,37 @@
+import { memo } from 'react'
+
+/**
+ * @typedef {Object} Notice
+ * @property {string} titulo Título do aviso.
+ * @property {string} texto Conteúdo resumido do aviso.
+ */
+
+/**
+ * Painel com os avisos do dia.
+ *
+ * @param {{ notices: Notice[] }} props Propriedades contendo os avisos.
+ * @returns {import('react').JSX.Element} Painel de avisos.
+ */
+function NoticesPanelComponent ({ notices }) {
+  return (
+    <div className="panel" style={{ marginTop: 18 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <h3 className="section-title" style={{ margin: 0 }}>Avisos do dia</h3>
+        <a className="seeall" href="#">Ver todos</a>
+      </div>
+      <div className="notice">
+        {notices.map((notice) => (
+          <div key={notice.titulo} className="notice-item">
+            <h4>{notice.titulo}</h4>
+            <p>{notice.texto}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const NoticesPanel = memo(NoticesPanelComponent)
+NoticesPanel.displayName = 'NoticesPanel'
+
+export default NoticesPanel

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,63 @@
+import { memo } from 'react'
+
+/**
+ * @typedef {Object} SidebarLink
+ * @property {string} icon Emoji or icon representing the action.
+ * @property {string} label Visible label for the link.
+ * @property {string} href Target URL for the link.
+ * @property {boolean} [isActive] Flag indicating whether the link is currently active.
+ */
+
+/** @type {SidebarLink[]} */
+const SIDEBAR_LINKS = [
+  { icon: '🏠', label: 'Painel', href: '#', isActive: true },
+  { icon: '💳', label: 'Contribuições', href: '#' },
+  { icon: '📝', label: 'Inscrição', href: '#' },
+  { icon: '📚', label: 'Planos de estudo', href: '#' },
+  { icon: '🗂️', label: 'Pausar módulo', href: '#' },
+  { icon: '🎯', label: 'Resultados', href: '#' },
+  { icon: '🔔', label: 'Avisos', href: '#' },
+  { icon: '📅', label: 'Agenda', href: '#' }
+]
+
+/** @type {SidebarLink} */
+const LOGOUT_LINK = { icon: '🚪', label: 'Sair', href: '#' }
+
+/**
+ * Renderiza a barra lateral de navegação do painel.
+ *
+ * @returns {import('react').JSX.Element} Estrutura JSX da barra lateral.
+ */
+function SidebarComponent () {
+  return (
+    <aside className="sidebar">
+      <div className="brand" aria-label="Logo">
+        <svg viewBox="0 0 24 24" role="img" aria-label="cap">
+          <path d="M12 2 1 7l11 5 9-4.09V14h2V7L12 2zm-7 9.27V17c0 2.76 3.5 8 5 8 5s8-2.24 8-5v-2.73l-8 3.64-8-3.64z" />
+        </svg>
+      </div>
+      <nav className="nav">
+        {SIDEBAR_LINKS.map((link) => (
+          <a
+            key={link.label}
+            className={link.isActive ? 'active' : undefined}
+            href={link.href}
+          >
+            <span className="icon">{link.icon}</span>
+            {link.label}
+          </a>
+        ))}
+      </nav>
+      <div className="spacer" />
+      <a className="nav logout" href={LOGOUT_LINK.href}>
+        <span className="icon">{LOGOUT_LINK.icon}</span>
+        {LOGOUT_LINK.label}
+      </a>
+    </aside>
+  )
+}
+
+const Sidebar = memo(SidebarComponent)
+Sidebar.displayName = 'Sidebar'
+
+export default Sidebar

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -1,0 +1,82 @@
+import { memo, useCallback } from 'react'
+
+/**
+ * @typedef {Object} Usuario
+ * @property {string} nome Nome do usuário autenticado.
+ * @property {string} periodo Período ou turma do usuário autenticado.
+ */
+
+/**
+ * Cria manipuladores de foco e blur para destacar o campo de pesquisa.
+ *
+ * @param {string} focusShadow Valor de sombra aplicado ao focar.
+ * @param {string} blurShadow Valor de sombra aplicado ao perder foco.
+ * @returns {{
+ *   handleFocus: import('react').FocusEventHandler<HTMLInputElement>,
+ *   handleBlur: import('react').FocusEventHandler<HTMLInputElement>
+ * }} Manipuladores memorizados de foco e blur.
+ */
+function useFocusShadow (focusShadow, blurShadow) {
+  /**
+   * @type {import('react').FocusEventHandler<HTMLInputElement>}
+   */
+  const handleFocus = useCallback((event) => {
+    if (event.currentTarget.parentElement) {
+      event.currentTarget.parentElement.style.boxShadow = focusShadow
+    }
+  }, [focusShadow])
+
+  /**
+   * @type {import('react').FocusEventHandler<HTMLInputElement>}
+   */
+  const handleBlur = useCallback((event) => {
+    if (event.currentTarget.parentElement) {
+      event.currentTarget.parentElement.style.boxShadow = blurShadow
+    }
+  }, [blurShadow])
+
+  return { handleFocus, handleBlur }
+}
+
+/**
+ * Barra superior com busca e informações do usuário.
+ *
+ * @param {{ usuario: Usuario }} props Propriedades do componente.
+ * @returns {import('react').JSX.Element} Estrutura visual da barra superior.
+ */
+function TopbarComponent ({ usuario }) {
+  const { handleFocus, handleBlur } = useFocusShadow(
+    '0 12px 30px rgba(21,13,57,.12)',
+    'var(--shadow)'
+  )
+
+  return (
+    <div className="topbar">
+      <div className="search" role="search">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+          <path d="M11 4a7 7 0 1 1 0 14 7 7 0 0 1 0-14Zm10 17-5.2-5.2" stroke="#999" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+        <input
+          type="text"
+          placeholder="Pesquisar"
+          aria-label="search"
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+        />
+      </div>
+      <div className="profile">
+        <div className="badge" title="alertas" />
+        <div className="avatar">BR</div>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>{usuario.nome}</div>
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>{usuario.periodo}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const Topbar = memo(TopbarComponent)
+Topbar.displayName = 'Topbar'
+
+export default Topbar

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,7 @@
+export { default as Sidebar } from './Sidebar.jsx'
+export { default as Topbar } from './Topbar.jsx'
+export { default as Hero } from './Hero.jsx'
+export { default as FinancialCards } from './FinancialCards.jsx'
+export { default as CoursesList } from './CoursesList.jsx'
+export { default as InstructorsPanel } from './InstructorsPanel.jsx'
+export { default as NoticesPanel } from './NoticesPanel.jsx'

--- a/src/context/StudyContext.jsx
+++ b/src/context/StudyContext.jsx
@@ -1,30 +1,91 @@
 import { createContext, useContext } from 'react'
 
-export const StudyContext = createContext(null)
+/**
+ * @typedef {Object} Usuario
+ * @property {string} nome Nome do usuário autenticado.
+ * @property {string} periodo Período ou turma do usuário.
+ */
 
-export function StudyProvider({ children }) {
-  const data = {
-    usuario: { nome: 'Bruno', periodo: '3º ano' },
-    financas: {
-      aContribuir: 120.00,
-      contribuido: 80.00,
-      outros: 15.00
-    },
-    instrutores: [
-      { nome: 'Pr. Ana Silva' },
-      { nome: 'Prof. João Mendes' },
-      { nome: 'Pr. Lucas Barros' }
-    ],
-    avisos: [
-      { titulo: 'Leitura da semana', texto: 'Mateus 5–7. Foque no Sermão do Monte.' },
-      { titulo: 'Agenda de prova', texto: 'Quiz de Hermenêutica no sábado às 10h.' }
-    ],
-    cursos: [
-      { titulo: 'Evangelhos Sinópticos', desc: 'Mateus, Marcos e Lucas. Contexto histórico e literário.' },
-      { titulo: 'Fundamentos de Hermenêutica', desc: 'Princípios de interpretação. Gêneros e contexto.' }
-    ]
-  }
-  return <StudyContext.Provider value={data}>{children}</StudyContext.Provider>
+/**
+ * @typedef {Object} Financas
+ * @property {number} aContribuir Valor pendente de contribuição.
+ * @property {number} contribuido Valor já contribuído no mês.
+ * @property {number} outros Outros valores financeiros.
+ */
+
+/**
+ * @typedef {{ nome: string }} Instructor
+ */
+
+/**
+ * @typedef {Object} Aviso
+ * @property {string} titulo Título do aviso.
+ * @property {string} texto Descrição do aviso.
+ */
+
+/**
+ * @typedef {Object} Course
+ * @property {string} titulo Título do curso.
+ * @property {string} desc Descrição do curso.
+ */
+
+/**
+ * @typedef {Object} StudyData
+ * @property {Usuario} usuario Dados do usuário autenticado.
+ * @property {Financas} financas Resumo financeiro do usuário.
+ * @property {Instructor[]} instrutores Lista de instrutores.
+ * @property {Aviso[]} avisos Lista de avisos do dia.
+ * @property {Course[]} cursos Cursos em andamento.
+ */
+
+/** @type {StudyData} */
+const STUDY_DATA = {
+  usuario: { nome: 'Bruno', periodo: '3º ano' },
+  financas: {
+    aContribuir: 120.00,
+    contribuido: 80.00,
+    outros: 15.00
+  },
+  instrutores: [
+    { nome: 'Pr. Ana Silva' },
+    { nome: 'Prof. João Mendes' },
+    { nome: 'Pr. Lucas Barros' }
+  ],
+  avisos: [
+    { titulo: 'Leitura da semana', texto: 'Mateus 5–7. Foque no Sermão do Monte.' },
+    { titulo: 'Agenda de prova', texto: 'Quiz de Hermenêutica no sábado às 10h.' }
+  ],
+  cursos: [
+    { titulo: 'Evangelhos Sinópticos', desc: 'Mateus, Marcos e Lucas. Contexto histórico e literário.' },
+    { titulo: 'Fundamentos de Hermenêutica', desc: 'Princípios de interpretação. Gêneros e contexto.' }
+  ]
 }
 
-export const useStudy = () => useContext(StudyContext)
+export const StudyContext = createContext(/** @type {StudyData | null} */ (null))
+
+/**
+ * Provedor de dados do estudo que encapsula a aplicação.
+ *
+ * @param {{ children: import('react').ReactNode }} props Propriedades do provedor.
+ * @returns {import('react').JSX.Element} Provedor de contexto renderizado.
+ */
+export function StudyProvider ({ children }) {
+  return (
+    <StudyContext.Provider value={STUDY_DATA}>
+      {children}
+    </StudyContext.Provider>
+  )
+}
+
+/**
+ * Hook para acessar os dados de estudo dentro do contexto.
+ *
+ * @returns {StudyData} Dados de estudo disponíveis no contexto.
+ */
+export function useStudy () {
+  const context = useContext(StudyContext)
+  if (!context) {
+    throw new Error('useStudy deve ser utilizado dentro de um StudyProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- modularize the dashboard into dedicated Sidebar, Topbar, Hero, FinancialCards, CoursesList, InstructorsPanel and NoticesPanel components with memoization and JSDoc typing
- restructure Dashboard to orchestrate child components while memoizing derived data such as financial cards and current date
- harden StudyContext with typed data definitions, usage guard for the hook and add a gitignore for build artefacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04d9d281883309594ad9e49a81c42